### PR TITLE
Fix/async execute

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           name: Push nuget package
           command: |
             cd ./src/Ouroboros/bin/Release
-            dotnet nuget push Ouroboros.2.0.0.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
+            dotnet nuget push Ouroboros.2.1.0.nupkg -k $NUGET_API_KEY -s https://api.nuget.org/v3/index.json
 
 workflows:
    version: 2

--- a/src/Ouroboros/Ouroboros.PublicTypes.fs
+++ b/src/Ouroboros/Ouroboros.PublicTypes.fs
@@ -129,7 +129,7 @@ type Apply<'DomainState, 'DomainEvent, 'DomainError> =
 type Execute<'DomainState, 'DomainCommand, 'DomainEvent, 'DomainError> =
     'DomainState
      -> DomainCommand<'DomainCommand>
-     -> Result<DomainEvent<'DomainEvent> list, 'DomainError>
+     -> AsyncResult<DomainEvent<'DomainEvent> list, 'DomainError>
 
 type Handle<'DomainCommand, 'DomainEvent, 'DomainError> =
     EntityId

--- a/src/Ouroboros/Ouroboros.fsproj
+++ b/src/Ouroboros/Ouroboros.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>Ouroboros</RootNamespace>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\ameier38\fsharp-common\Result.fs">

--- a/src/Tests/Dog.Implementation.fs
+++ b/src/Tests/Dog.Implementation.fs
@@ -14,7 +14,7 @@ type Apply =
 type Execute =
     DogState
      -> DomainCommand<DogCommand>
-     -> Result<DomainEvent<DogEvent> list, DogError>
+     -> AsyncResult<DomainEvent<DogEvent> list, DogError>
 
 module Dog =
     let create name breed =
@@ -104,10 +104,11 @@ module Execute =
         event
         |> DomainEvent.fromDogEvent source effectiveDate
         |> Result.map List.singleton
+        |> AsyncResult.ofResult
     let fail message =
         message
         |> DogError.Validation
-        |> Error
+        |> AsyncResult.ofError
     let create source effectiveDate dog = function
         | NoDog ->
             DogEvent.Born dog 


### PR DESCRIPTION
### Change Summary
- change execute function to return `AsyncResult` since it could require and external call to validate if an event should be created